### PR TITLE
Procfile修正

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails server -b 0.0.0.0 -p 3000
+web: bin/rails server -b 0.0.0.0 -p $PORT
 js: yarn build --watch
 css: yarn build:css --watch


### PR DESCRIPTION
デプロイ完了後、15分ほどで502が表示されてしまうようになった。

```
==> Detected service running on port 10000
==> Docs on specifying a port: https://render.com/docs/web-services#port-binding
[126] === puma shutdown: 2025-01-21 09:35:01 +0000 ===
[126] - Goodbye!
[126] - Gracefully shutting down workers...
```
上記ログに対して、Procfileで-p 3000と記述していたため、修正して再デプロイ施行。