### PR TITLE
ルーティング作成

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "tasks#index"
 end


### PR DESCRIPTION
 googleのapps scriptで、Renderがスリープしないよう設定。
その際ルーティング設定がないと実行できないため、仮のルーティング作成。