### PR TITLE
画像投稿機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "bootsnap", require: false
 
 gem "sorcery", "0.16.3"
 gem "rails-i18n"
+gem "activestorage-validator"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       activerecord (= 7.2.2.1)
       activesupport (= 7.2.2.1)
       marcel (~> 1.0)
+    activestorage-validator (0.4.0)
+      rails (>= 6.1.0)
     activesupport (7.2.2.1)
       base64
       benchmark (>= 0.3)
@@ -341,6 +343,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  activestorage-validator
   better_errors
   bootsnap
   brakeman

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -21,10 +21,10 @@ class RecipesController < ApplicationController
 
   def recipe_params
     params.require(:recipe).permit(
-      :title, :model, :preheat_time, :preheat_temperature, :point,
+      :title, :model, :preheat_time, :preheat_temperature, :point, :main_image,
       heats_attributes: [ :id, :time, :temperature, :_destroy ],
       ingredients_attributes: [ :id, :name, :quantity, :_destroy ],
-      instructions_attributes: [ :id, :step_number, :description, :_destroy ]
+      instructions_attributes: [ :id, :step_number, :description, :image, :_destroy ]
     )
   end
 end

--- a/app/models/instruction.rb
+++ b/app/models/instruction.rb
@@ -1,7 +1,10 @@
 class Instruction < ApplicationRecord
   belongs_to :recipe
+  has_one_attached :image
 
   after_create :set_step_number
+
+  validates :image, blob: { content_type: [ "image/png", "image/jpg", "image/jpeg" ], size_range: 1..(5.megabytes) }
 
   private
 

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -4,6 +4,8 @@ class Recipe < ApplicationRecord
   has_many :ingredients, dependent: :destroy
   has_many :instructions, dependent: :destroy
 
+  has_one_attached :main_image
+
   accepts_nested_attributes_for :heats, allow_destroy: true
   accepts_nested_attributes_for :ingredients, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :instructions, allow_destroy: true, reject_if: :all_blank
@@ -11,4 +13,6 @@ class Recipe < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :model, presence: true, length: { maximum: 255 }
   validates :point, length: { maximum: 65_535 }
+
+  validates :main_image, blob: { content_type: [ "image/png", "image/jpg", "image/jpeg" ], size_range: 1..(5.megabytes) }
 end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -20,11 +20,15 @@
       <%= f.submit "検索", class: "bg-orange-600 text-white rounded px-4 py-1" %>
     <% end %>
   </div>
+
   <!-- レシピ一覧 -->
   <div class="grid grid-cols-2 gap-2 mx-[20px]">
     <% @recipes.each do |recipe| %>
-      <div class="relative bg-orange-200 text-white text-sm px-4 py-14 rounded">
-        <div class="absolute bottom-2 left-2">
+      <div class="relative bg-orange-200 rounded w-full h-[130px]">
+        <% if recipe.main_image.attached? %>
+          <%= image_tag recipe.main_image, class: "w-full h-[130px] object-cover rounded" %>
+        <% end %>
+        <div class="absolute bottom-2 left-2 text-white font-bold text-sm">
           <%= recipe.title %>
         </div>
       </div>

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -9,16 +9,13 @@
     </div>
   </div>
 
-  <!-- Image Upload -->
-  <div class="w-full bg-gray-200 h-48 flex justify-center items-center mb-2">
-    <button>
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-      </svg>
-    </button>
-  </div>
-
   <%= form_with model: @recipe, local: true, id: "post_form", class: "w-full" do |f| %>
+
+    <!-- Image Upload -->
+    <div class="w-full bg-gray-100 h-56 flex justify-center items-center mb-2">
+      <%= f.file_field :main_image %>
+    </div>
+
     <!-- Title Input -->
     <div>
       <%= f.text_field :title, placeholder: "なにを作ったのか教えてください！", class: "w-full bg-white border border-gray-300 rounded px-4 py-2 mb-1" %>
@@ -89,20 +86,19 @@
 
 
     <!-- Steps Section -->
-    <div id="steps-section" class="steps-Section w-full mb-4">
+    <div id="steps-section" class="steps-section w-full mb-4">
       <%= f.fields_for :instructions do |instruction| %>
         <label class="block text-gray-700 mb-2">作り方</label>
-        <div class="step-item flex items-center space-x-2 mb-2">
+        <div class="step-item flex items-center space-x-1 mb-2">
           <button class="remove-step text-gray-700 px-2" type="button">×</button>
+          <%= instruction.file_field :image, class: "bg-gray-100 rounded px-1 py-2 w-14" %>
           <span class="step-number text-gray-400"><%= instruction.object.step_number %></span>
           <%= instruction.text_field :description, type: "text", class: "w-full bg-white border border-gray-300 rounded px-4 py-2" %>
-          <% end %>
           <button class="add-step text-gray-700 px-4 py-2 rounded" type="button">＋</button>
         </div>
-        <div class="h-16 w-16 flex justify-center items-center mb-2 border border-gray-300 rounded">
-          <button>＋</button>
-        </div>
+      <% end %>
     </div>
+
 
     <!-- Tips Section -->
     <div class="w-full mb-4">
@@ -150,10 +146,11 @@
           newStep.className = "step-item flex items-center space-x-2 mb-2";
           newStep.innerHTML = `
             <button class="remove-step text-gray-700 px-2" type="button">×</button>
+            <input type="file" name="recipe[instructions_attributes][${stepIndex}][image]" class="block bg-gray-100 rounded px-1 py-2 w-14" />
             <span class="step-number text-gray-400">${stepIndex + 1}</span>
             <input type="text" name="recipe[instructions_attributes][${stepIndex}][description]" class="w-full bg-white border border-gray-300 rounded px-4 py-2" />
             <button class="add-step text-gray-700 px-4 py-2 rounded" type="button">＋</button>
-            <div class="h-10 w-16 flex justify-center items-center mb-2 border border-gray-300 rounded"><button>＋</button></div>
+            </div>
           `;
           stepsSection.appendChild(newStep);
           updateStepNumbers();

--- a/db/migrate/20250129061101_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250129061101_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_28_020853) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_29_061101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "heats", force: :cascade do |t|
     t.integer "time", null: false
@@ -62,6 +90,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_28_020853) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "heats", "recipes"
   add_foreign_key "ingredients", "recipes"
   add_foreign_key "instructions", "recipes"


### PR DESCRIPTION
### 実装詳細
- [x] レシピ作成ページでmain_image(完成見本画像)1枚と、image(手順画像)複数枚を保存できるよう。
- [x] imageは手順(instruction)ごとに1枚ずつ保存できる。
- [x] 画像拡張子はpng, jpg, jpeg のみを許可し、サイズは5MB以下で設定。設定外の画像で保存しようとすると、エラーメッセージが表示される。
- [x] main_imageは保存されると、トップページにタイトルと共に表示される。