### PR TITLE
gem addressableのインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem "rails-i18n"
 gem "activestorage-validator"
 gem "aws-sdk-s3", require: false
 gem "nokogiri"
+gem 'addressable'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "rails-i18n"
 gem "activestorage-validator"
 gem "aws-sdk-s3", require: false
 gem "nokogiri"
-gem 'addressable'
+gem "addressable"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,6 +361,7 @@ PLATFORMS
 
 DEPENDENCIES
   activestorage-validator
+  addressable
   aws-sdk-s3
   better_errors
   bootsnap


### PR DESCRIPTION
gem addressableのインストールがされていなかったため、Renderデプロイ時にエラー発生。
gem addressableのインストール実行。