### PR TITLE
レシピ作成時にタグ付け機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "activestorage-validator"
 gem "aws-sdk-s3", require: false
 gem "nokogiri"
 gem "addressable"
-gem 'acts-as-taggable-on'
+gem "acts-as-taggable-on"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem "activestorage-validator"
 gem "aws-sdk-s3", require: false
 gem "nokogiri"
 gem "addressable"
+gem 'acts-as-taggable-on'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,9 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+    acts-as-taggable-on (12.0.0)
+      activerecord (>= 7.1, < 8.1)
+      zeitwerk (>= 2.4, < 3.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
@@ -364,6 +367,7 @@ PLATFORMS
 
 DEPENDENCIES
   activestorage-validator
+  acts-as-taggable-on
   addressable
   aws-sdk-s3
   better_errors

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -53,7 +53,7 @@ class RecipesController < ApplicationController
 
   def recipe_params
     params.require(:recipe).permit(
-      :title, :model, :preheat_time, :preheat_temperature, :point, :main_image,
+      :title, :model, :preheat_time, :preheat_temperature, :point, :main_image, :tag_list,
       heats_attributes: [ :id, :time, :temperature, :_destroy ],
       ingredients_attributes: [ :id, :name, :quantity, :_destroy ],
       instructions_attributes: [ :id, :step_number, :description, :image, :_destroy ],

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -7,6 +7,8 @@ class Recipe < ApplicationRecord
 
   has_one_attached :main_image
 
+  acts_as_taggable_on :tags
+
   accepts_nested_attributes_for :heats, allow_destroy: true
   accepts_nested_attributes_for :ingredients, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :instructions, allow_destroy: true, reject_if: :all_blank

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -23,11 +23,9 @@
 
     <!-- Tags -->
     <div class="section w-full mb-4" data-section="tags">
-      <label class="block text-gray-700 mb-2">タグを追加</label>
-      <div class="item flex items-center space-x-2 mb-2">
-        <button class="remove-item text-gray-700 px-2" type="button">×</button>
-        <input type="text" class="bg-white border border-gray-300 rounded px-4 py-2" placeholder="タグ" />
-        <button class="add-item text-gray-700 px-4 py-2 rounded self-end" type="button">＋</button>
+      <div class="w-full mb-4">
+        <%= f.label :tag_list, "タグ", class: "block text-gray-700 mb-2" %>
+        <%= f.text_field :tag_list, value: @recipe.tag_list.join(","), class: "bg-white border border-gray-300 rounded px-4 py-2", placeholder: " , で区切ってください" %>
       </div>
     </div>
 
@@ -172,50 +170,6 @@
             }
           }
         });
-      });
-    });
-
-    // Tag Sections
-    document.addEventListener("turbo:load", () => {
-      function updateNumbers(section) {
-        const items = section.querySelectorAll(".item");
-        items.forEach((item, index) => {
-          const numberElement = item.querySelector(".step-number");
-          if (numberElement) {
-            numberElement.textContent = index + 1;
-          }
-        });
-      }
-
-      document.querySelectorAll(".section").forEach((section) => {
-        if (section.dataset.listenerAdded) return;
-        section.dataset.listenerAdded = "true"; // フラグ設定
-
-        section.addEventListener("click", (e) => {
-          if (e.target.classList.contains("add-item") && e.target.type === "button") {
-            e.preventDefault();
-            const sectionType = section.getAttribute("data-section");
-            const newItem = document.createElement("div");
-            newItem.className = "item flex items-center space-x-2 mb-2";
-            const inputClass = sectionType === "tags" ? "w-1/3" : "w-full";
-            newItem.innerHTML = `
-              <button class="remove-item text-gray-700 px-2" type="button">×</button>
-              <input type="text" class="${inputClass} bg-white border border-gray-300 rounded px-4 py-2" placeholder="" />
-              <button class="add-item text-gray-700 px-4 py-2 rounded" type="button">＋</button>
-            `;
-            section.appendChild(newItem);
-            updateNumbers(section);
-          } else if (e.target.classList.contains("remove-item") && e.target.type === "button") {
-            e.preventDefault();
-            const items = section.querySelectorAll(".item");
-            if (items.length > 1) {
-              e.target.closest(".item").remove();
-              updateNumbers(section);
-            }
-          }
-        });
-
-        updateNumbers(section);
       });
     });
 

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -123,14 +123,18 @@
     <div class="px-6 py-1">
       <% @recipe.embeds.each do |embed| %>
         <% if embed.kind == "website" %>
-          <%= link_to embed.safe_url.to_s, target: "_blank", rel: "noopener noreferrer", class: "block" do %>
-            <div class="card">
-              <p><%= embed.ogp_site_name.presence || "サイト名なし" %></p>
+          <%= link_to embed.safe_url.to_s, target: "_blank", rel: "noopener noreferrer", class: "block w-full max-w-sm rounded-lg shadow-md overflow-hidden border border-gray-300 bg-white" do %>
+            <div >
               <% if embed.ogp_image_url.present? %>
-                <img src="<%= embed.ogp_image_url %>" alt="OGP Image">
+                <div >
+                  <img src="<%= embed.ogp_image_url %>" alt="OGP Image" class="w-full h-full object-cover">
+                </div>
               <% end %>
-              <p><%= embed.ogp_title.presence || "タイトルなし" %></p>
-              <p><%= embed.ogp_description.presence || "詳細なし" %></p>
+              <div class=" p-2">
+                <p class="text-xs text-gray-600 font-semibold"><%= embed.ogp_site_name.presence || "" %></p>
+                <p class="text-sm font-bold line-clamp-2"><%= embed.ogp_title.presence || "" %></p>
+                <p class="text-xs text-gray-500 line-clamp-2"><%= embed.ogp_description.presence || "" %></p>
+              </div>
             </div>
           <% end %>
         <% elsif embed.kind == "youtube" %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -37,6 +37,17 @@
     <%= @recipe.title %>
   </div>
 
+  <div class="px-6 py-2">
+    <div class="font-bold text-gray-600">タグ</div>
+    <% if @recipe.tag_list.present? %>
+      <% @recipe.tag_list.each do |tag| %>
+        <span class="bg-amber-500 text-gray-700 badge badge-info mr-1 mb-1 text-white rounded ">
+          <%= tag %>
+        </span>
+      <% end %>
+    <% end %>
+  </div>
+
   <div class="grid grid-cols-2 gap-4 px-6 py-2">
     <div>
       <div class="font-bold text-gray-600">予熱</div>

--- a/db/migrate/20250203045812_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20250203045812_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20250203045813_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20250203045813_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+class AddMissingUniqueIndices < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20250203045814_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20250203045814_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20250203045815_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20250203045815_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20250203045816_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20250203045816_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+
+class ChangeCollationForTagNames < ActiveRecord::Migration[6.0]
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20250203045817_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20250203045817_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+class AddMissingIndexesOnTaggings < ActiveRecord::Migration[6.0]
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                 :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                   :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                               :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                         name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                name: 'taggings_idy'
+    end
+  end
+end

--- a/db/migrate/20250203045818_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20250203045818_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 7)
+class AddTenantToTaggings < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.taggings_table, :tenant, :string, limit: 128
+    add_index ActsAsTaggableOn.taggings_table, :tenant unless index_exists? ActsAsTaggableOn.taggings_table, :tenant
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, :tenant
+    remove_column ActsAsTaggableOn.taggings_table, :tenant
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_01_073721) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_03_045818) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -94,6 +94,37 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_01_073721) do
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end
 
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.string "taggable_type"
+    t.bigint "taggable_id"
+    t.string "tagger_type"
+    t.bigint "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at", precision: nil
+    t.string "tenant", limit: 128
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+    t.index ["tagger_type", "tagger_id"], name: "index_taggings_on_tagger_type_and_tagger_id"
+    t.index ["tenant"], name: "index_taggings_on_tenant"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email"
     t.string "crypted_password"
@@ -110,4 +141,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_01_073721) do
   add_foreign_key "ingredients", "recipes"
   add_foreign_key "instructions", "recipes"
   add_foreign_key "recipes", "users"
+  add_foreign_key "taggings", "tags"
 end


### PR DESCRIPTION
・gem 'acts-as-taggable-on'を使用して、レシピ作成時にタグがつけられるように実装。
・複数個のタグを登録する場合は' , 'で区切るようプレイスホルダーに記述。
・タグはレシピ詳細画面で確認できる。