### PR TITLE
一時的にアドレス変更機能を停止

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
   resources :bookmarks, only: %i[index create destroy]
   resources :contacts, only: %i[new create]
   resources :password_resets, only: %i[ new create edit update ]
-  resources :activations, only: %i[new edit update]
+  # resources :activations, only: %i[new edit update]
 
   get "login", to: "user_sessions#new"
   post "login", to: "user_sessions#create"


### PR DESCRIPTION
本番環境でログインができない問題の精査のため、一時的にメールアドレス変更機能の動作を停止。