### PR TITLE
ログインできない不具合の修正

### DIFF
--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -380,7 +380,8 @@ Rails.application.config.sorcery.configure do |config|
     # Do you want to prevent users who did not activate by email from logging in?
     # Default: `true`
     #
-    # user.prevent_non_active_users_to_login =
+    user.prevent_non_active_users_to_login = false
+    activation_required = false
 
     # -- reset_password --
     # Password reset token attribute name.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
   resources :bookmarks, only: %i[index create destroy]
   resources :contacts, only: %i[new create]
   resources :password_resets, only: %i[ new create edit update ]
-  # resources :activations, only: %i[new edit update]
+  resources :activations, only: %i[new edit update]
 
   get "login", to: "user_sessions#new"
   post "login", to: "user_sessions#create"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -147,10 +147,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_26_072617) do
     t.datetime "reset_password_token_expires_at"
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
+    t.string "unconfirmed_email"
     t.string "activation_state", default: "active"
     t.string "activation_token"
     t.datetime "activation_token_expires_at"
-    t.string "unconfirmed_email"
     t.index ["activation_token"], name: "index_users_on_activation_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end


### PR DESCRIPTION
sorcery.rbにて、新規登録時にactivation_state を"pending" に変更する処理を無効に設定。
新規登録時にメールで確認しなくてもログインできるよう設定。