### PR TITLE
メールの送信先を修正

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -8,6 +8,6 @@ class UserMailer < ApplicationMailer
   def activation_needed_email(user)
     @user = user
     @url = edit_activation_url(@user.activation_token)
-    mail(to: @user.email, subject: "メールアドレス変更の確認")
+    mail(to: @user.unconfirmed_email, subject: "メールアドレス変更の確認")
   end
 end


### PR DESCRIPTION
メールアドレス変更時に送信されるメールの宛先が、旧メールアドレスになっていたため、新メールアドレスに修正。